### PR TITLE
Update nodejs-cd.yml

### DIFF
--- a/.github/workflows/nodejs-cd.yml
+++ b/.github/workflows/nodejs-cd.yml
@@ -49,4 +49,5 @@ jobs:
       run: cat ./bin/app-data.js
 
     - name: Run Acceptance Tests
-      run: npm run test:acceptance
+      # run: npm run test:acceptance
+      run: npx jest test/acceptance


### PR DESCRIPTION
I think we have a file permission issue with jest. This is probably because the files permissions are not preserved when downloading the node_modules. Maybe we can use npx instead of npm run jest