### PR TITLE
Update create-release.yml

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -116,10 +116,10 @@ jobs:
           cat attributes.json 
 
           curl -i -X POST "https://upload.box.com/api/2.0/files/content" \
-               -H "authorization: Bearer ${{ env.access_token }}” \
+               -H "authorization: Bearer ${{env.access_token}}” \
                -H "\"content-type\": multipart/form-data" \
                -F attributes=@attributes.json \               
-               -F file=@VMP-Release-${{ env.VERSION }}.zip
+               -F file=@VMP-Release-${{env.VERSION}}.zip
         
     - name: Revoke Access Token
       run: |


### PR DESCRIPTION
Tool spaces out for ${{xxxxx}} I've run into a problem before where sometime this works and sometimes it does not. ${{ xxxxx }}