### PR TITLE
Added a comment to file to trigger it a run again for debugging

### DIFF
--- a/.github/workflows/nodejs-cd.yml
+++ b/.github/workflows/nodejs-cd.yml
@@ -1,5 +1,6 @@
 name: NodeJS Continuous Delivery
 
+# It may be a bad idea to have both the workflow dispatch trigger enabled at the same time as the schedule trigger
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Trying to see if our workflow is broken now or if GitHub is just having a bad day. Also, I was impatient waiting for the cron to run this workflow so I kicked it off manually. Of course then both jobs were pending. Once I saw the scheduled run I killed my my manual run. This should not have caused an issue but it is an extra variable to consider while debugging.