### PR TITLE
Update nodejs-ci.yml

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -83,6 +83,7 @@ jobs:
       with:
         name: rc-${{ github.run_number }}-binaries
         path: ./
+        include-hidden-files: true
   
   merge_to_main:
     needs: build_and_test


### PR DESCRIPTION
Looks like actions/upload-artifact@v4 changed to not upload hidden files by default. Overriding the default hoping this fixes the missing .bin dir in node_modules that is causing our acceptance tests to fail in the nodejs-cd workflow